### PR TITLE
misc(ua): Add the UA to the request

### DIFF
--- a/Insights.xcodeproj/project.pbxproj
+++ b/Insights.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1D4531D1209C870C00B26CF9 /* InsightsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4531D0209C870C00B26CF9 /* InsightsTests.swift */; };
 		1D4531D3209C870C00B26CF9 /* InstantSearchInsights.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D4531C5209C870C00B26CF9 /* InstantSearchInsights.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1D575DE020C98BFA00D20E33 /* MockWebService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D575DDF20C98BFA00D20E33 /* MockWebService.swift */; };
+		1D577E6D2236913A00EE6D94 /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D577E6C2236913A00EE6D94 /* UserAgentTests.swift */; };
 		1D77D88120C9722B009EC531 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D77D88020C9722B009EC531 /* Config.swift */; };
 		1D958AF220BD71ED0058230A /* Insights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D958AF120BD71ED0058230A /* Insights.swift */; };
 		1D958AF820BD8A6E0058230A /* InsightsTestObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D958AF720BD8A6E0058230A /* InsightsTestObjC.m */; };
@@ -227,6 +228,7 @@
 		1D4531D0209C870C00B26CF9 /* InsightsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsTests.swift; sourceTree = "<group>"; };
 		1D4531D2209C870C00B26CF9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1D575DDF20C98BFA00D20E33 /* MockWebService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebService.swift; sourceTree = "<group>"; };
+		1D577E6C2236913A00EE6D94 /* UserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
 		1D77D88020C9722B009EC531 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		1D958AF120BD71ED0058230A /* Insights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Insights.swift; sourceTree = "<group>"; };
 		1D958AF720BD8A6E0058230A /* InsightsTestObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InsightsTestObjC.m; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 				AFD96DD8219464EC00E13993 /* ObjectIDsOrFiltersTests.swift */,
 				AF56CF3E21B04F0200B5EABB /* APIEndpointTests.swift */,
 				AFB9771221C289FA00094E1E /* XCTest+Int64.swift */,
+				1D577E6C2236913A00EE6D94 /* UserAgentTests.swift */,
 			);
 			path = Unit;
 			sourceTree = "<group>";
@@ -863,6 +866,7 @@
 				AFC30C012191C1AB00AA72B0 /* ClickTests.swift in Sources */,
 				AFD431E8219329D700A94D5E /* TestEventProcessor.swift in Sources */,
 				AFD431E4219322EF00A94D5E /* EventTrackerTests.swift in Sources */,
+				1D577E6D2236913A00EE6D94 /* UserAgentTests.swift in Sources */,
 				1D575DE020C98BFA00D20E33 /* MockWebService.swift in Sources */,
 				AFC30C032191C1B900AA72B0 /* ViewTests.swift in Sources */,
 				AF56CF3F21B04F0200B5EABB /* APIEndpointTests.swift in Sources */,

--- a/Insights/Networking/WebService.swift
+++ b/Insights/Networking/WebService.swift
@@ -80,7 +80,7 @@ extension WebService {
     return nil
     #endif
   }
-  
+  // Computing the User Agent. Expected output: insights-ios (2.1.0); iOS (12.1.0)
   internal static func computeUserAgent() -> String {
     var userAgents: [LibraryVersion] = []
     

--- a/Insights/Networking/WebService.swift
+++ b/Insights/Networking/WebService.swift
@@ -18,7 +18,9 @@ class WebService {
     }
     
     public func makeRequest<A, E>(for resource: Resource<A, E>) -> URLRequest {
-        return URLRequest(resource: resource)
+        var request = URLRequest(resource: resource)
+        request.addValue(WebService.computeUserAgent(), forHTTPHeaderField: "User-Agent")
+        return request
     }
     
     public func load<A, E>(resource: Resource<A, E>, completion: @escaping (Result<A>) -> Void) {
@@ -55,6 +57,51 @@ class WebService {
             }
         }).resume()
     }
+}
+
+// MARK: UserAgent
+typealias LibraryVersion = (name: String, version: String)
+extension WebService {
+  
+  /// The operating system's name.
+  ///
+  /// - returns: The operating system's name, or nil if it could not be determined.
+  ///
+  internal static func osName() -> String? {
+    #if os(iOS)
+    return "iOS"
+    #elseif os(OSX)
+    return "macOS"
+    #elseif os(tvOS)
+    return "tvOS"
+    #elseif os(watchOS)
+    return "watchOS"
+    #else
+    return nil
+    #endif
+  }
+  
+  internal static func computeUserAgent() -> String {
+    var userAgents: [LibraryVersion] = []
+    
+    let packageVersion = Bundle(for: WebService.self).infoDictionary!["CFBundleShortVersionString"] as! String
+    userAgents.append(LibraryVersion(name: "insights-ios", version: packageVersion))
+    if let osInfo = osInfo() {
+      userAgents.append(osInfo)
+    }
+    return userAgents.map({ "\($0.name) (\($0.version))" }).joined(separator: "; ")
+  }
+  
+  internal static func osInfo() -> LibraryVersion? {
+    if #available(iOS 8.0, OSX 10.0, tvOS 9.0, *) {
+      let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+      let osVersionString = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+      if let osName = WebService.osName() {
+        return LibraryVersion(name: "\(osName)", version: osVersionString)
+      }
+    }
+    return nil
+  }
 }
 
 public protocol APIError: Error {

--- a/InsightsTests/Unit/UserAgentTests.swift
+++ b/InsightsTests/Unit/UserAgentTests.swift
@@ -1,0 +1,23 @@
+//
+//  UserAgentTests.swift
+//  InsightsTests
+//
+//  Created by Robert Mogos on 11/03/2019.
+//  Copyright © 2019 Algolia. All rights reserved.
+//
+
+import XCTest
+@testable import InstantSearchInsights
+
+class UserAgentTests: XCTestCase {
+  
+  func testUA() {
+    let packageVersion = Bundle(for: WebService.self).infoDictionary!["CFBundleShortVersionString"] as! String
+    guard let osInfo = WebService.osInfo() else {
+      XCTFail("Unable to fetch the OS info")
+      return
+    }
+    let ua = "insights-ios (\(packageVersion)); \(osInfo.name) (\(osInfo.version))"
+    XCTAssertEqual(ua, WebService.computeUserAgent())
+  }
+}

--- a/InsightsTests/Unit/UserAgentTests.swift
+++ b/InsightsTests/Unit/UserAgentTests.swift
@@ -17,7 +17,7 @@ class UserAgentTests: XCTestCase {
       XCTFail("Unable to fetch the OS info")
       return
     }
-    let ua = "insights-ios (\(packageVersion)); \(osInfo.name) (\(osInfo.version))"
-    XCTAssertEqual(ua, WebService.computeUserAgent())
+    let expectedUserAgent = "insights-ios (\(packageVersion)); \(osInfo.name) (\(osInfo.version))"
+    XCTAssertEqual(expectedUserAgent, WebService.computeUserAgent())
   }
 }


### PR DESCRIPTION
Add the User-Agent to the request. + the unit test to check is matching the expected format: `insights-ios (2.1.0); iOS (12.1.0)`