### PR TITLE
fix: Remove the id field from events package when sent to server

### DIFF
--- a/Insights/Event/EventsPackage.swift
+++ b/Insights/Event/EventsPackage.swift
@@ -145,8 +145,7 @@ extension EventsPackage: Syncable {
             }
             return nil
         }
-        
-        let serializedSelf = Dictionary(self)!
+        let serializedSelf = [CodingKeys.events.rawValue: Array(encodable:self.events)]
         let url = API.baseAPIURL(forRegion: region)
         return Resource<Bool, WebserviceError>(url: url,
                                                method: .post([], serializedSelf as AnyObject),

--- a/Insights/Extensions/Encodable.swift
+++ b/Insights/Extensions/Encodable.swift
@@ -31,7 +31,7 @@ extension Dictionary where Key == String, Value == Any {
 
 extension Array where Element == Any {
     
-    init?<T: Encodable>(_ encodable: T) {
+    init?<T: Encodable>(encodable: T) {
         guard let data = try? JSONEncoder().encode(encodable) else { return nil }
         guard let array = (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)) as? [Any] else {
             return nil

--- a/InsightsTests/Unit/EventsPackageTests.swift
+++ b/InsightsTests/Unit/EventsPackageTests.swift
@@ -160,8 +160,11 @@ class EventsPackageTests: XCTestCase {
         switch resource.method {
         case .post([], let body):
             let jsonDecoder = JSONDecoder()
-            let package = try! jsonDecoder.decode(EventsPackage.self, from: body)
-            XCTAssertEqual(package, eventsPackage)
+            let package = try! jsonDecoder.decode([String: Array<EventWrapper>].self, from: body)
+            XCTAssertNotNil(package[EventsPackage.CodingKeys.events.rawValue])
+            let expectedEvents = package[EventsPackage.CodingKeys.events.rawValue]!
+            XCTAssertEqual(expectedEvents.description,
+                           eventsPackage.events.description)
             
         default:
             XCTFail("Unexpected method")

--- a/InsightsTests/Unit/InsightsTests.swift
+++ b/InsightsTests/Unit/InsightsTests.swift
@@ -360,8 +360,8 @@ class InsightsTests: XCTestCase {
                     XCTAssertNotNil(data)
                     let jsonDecoder = JSONDecoder()
                     do {
-                        let package = try jsonDecoder.decode(EventsPackage.self, from: data)
-                        XCTAssertEqual(package.events.count, 1)
+                      let package = try jsonDecoder.decode([String: Array<EventWrapper>].self, from: data)
+                      XCTAssertNotNil(package[EventsPackage.CodingKeys.events.rawValue])
                         exp.fulfill()
                     } catch _ {
                         XCTFail("Unable to construct EventsPackage with provided JSON")


### PR DESCRIPTION
Previously, when sending the events, we were sending the id of the package as well. 
This change will removed it from the payload